### PR TITLE
refactoring/createDevon4jProjects

### DIFF
--- a/cobigen/index.asciidoc
+++ b/cobigen/index.asciidoc
@@ -20,7 +20,7 @@ To begin you need to install CobiGen and create a Java Project.
 == Install CobiGen and create Java Project
 --
 installCobiGen()
-createDevon4jProject("cobigenexample")
+createDevon4jProject("com.example.application.cobigenexample")
 --
 
 Create the entity class which will be passed to the cobigen cli generator later

--- a/devon4j-app/index.asciidoc
+++ b/devon4j-app/index.asciidoc
@@ -27,7 +27,7 @@ Now, we will create sample devon4j application with name *sampleapp*. This step 
 
 [step]
 --
-createDevon4jProject("sampleapp")
+createDevon4jProject("com.example.application.sampleapp")
 --
 
 Once sampleapp is created switch to next tab of IDE. In IDE explorer you can see folder structure like devonfw-> workspaces->main->sampleapp . 


### PR DESCRIPTION
createDevon4jProject should now get the base package as parameter not only the project-name

