### PR TITLE
changed dispatch action version to 1.0.0

### DIFF
--- a/.github/workflows/buildMain.yml
+++ b/.github/workflows/buildMain.yml
@@ -59,8 +59,8 @@ jobs:
       - name: run buildRun.sh ${{ github.event.inputs.logLevel }}
         run: sh buildRun.sh -p ${{ matrix.tutorial }} ${{ github.event.inputs.logLevel }}
       
-      - name: Repository dispatch
-        uses: guilouro/multiple-repositories-dispatch@v1
+      - name: Multiple Repositories Dispatcher
+        uses: guilouro/multiple-repositories-dispatch@v1.0.0
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repositories: |


### PR DESCRIPTION
Multiple repositories dispatch is not working 
Error Message --> Error: Unable to resolve action `guilouro/multiple-repositories-dispatch@v1`, unable to find version `v1`

probably because the version is currently v1 and not v1.0.0


